### PR TITLE
Fix dev setup and wheel build flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,5 @@ wheel: ## Build a distributable wheel into dist/
 		exit 1; \
 	fi
 	$(VENV_PY) -m pip install -r requirements-dev.txt
-	$(VENV_PY) -m build --wheel
+	$(VENV_PY) -c "import shutil; shutil.rmtree('build', ignore_errors=True)"
+	$(VENV_PY) -m build --wheel --no-isolation

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help: ## Show available make targets
 local-venv: ## Create local Python venv and install dependencies; activate it separately
 ifeq ($(OS),Windows_NT)
 	$(PYTHON_BIN) -m venv .venv
-	powershell -NoProfile -ExecutionPolicy Bypass -Command "& { .venv\Scripts\python.exe -m pip install --upgrade pip; .venv\Scripts\python.exe -m pip install -r requirements-dev.txt; .venv\Scripts\python.exe -m playwright install chromium }"
+	powershell -NoProfile -ExecutionPolicy Bypass -Command "& { $(VENV_PY) -m pip install --upgrade pip; $(VENV_PY) -m pip install -r requirements-dev.txt; $(VENV_PY) -m playwright install chromium }"
 else
 	$(PYTHON_BIN) -m venv .venv && $(VENV_PY) -m pip install --upgrade pip && $(VENV_PY) -m pip install -r requirements-dev.txt && $(VENV_PY) -m playwright install chromium
 endif

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ help: ## Show available make targets
 local-venv: ## Create local Python venv and install dependencies; activate it separately
 ifeq ($(OS),Windows_NT)
 	$(PYTHON_BIN) -m venv .venv
-	powershell -NoProfile -ExecutionPolicy Bypass -Command "& { . .venv\Scripts\Activate.ps1; python -m pip install --upgrade pip; pip install -r requirements-dev.txt; playwright install chromium }"
+	powershell -NoProfile -ExecutionPolicy Bypass -Command "& { .venv\Scripts\python.exe -m pip install --upgrade pip; .venv\Scripts\python.exe -m pip install -r requirements-dev.txt; .venv\Scripts\python.exe -m playwright install chromium }"
 else
-	$(PYTHON_BIN) -m venv .venv && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-dev.txt && playwright install chromium
+	$(PYTHON_BIN) -m venv .venv && $(VENV_PY) -m pip install --upgrade pip && $(VENV_PY) -m pip install -r requirements-dev.txt && $(VENV_PY) -m playwright install chromium
 endif
 
 .PHONY: audit

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ help: ## Show available make targets
 local-venv: ## Create local Python venv and install dependencies; activate it separately
 ifeq ($(OS),Windows_NT)
 	$(PYTHON_BIN) -m venv .venv
-	powershell -NoProfile -ExecutionPolicy Bypass -Command "& { . .venv\Scripts\Activate.ps1; python -m pip install --upgrade pip; pip install -r requirements.txt -r requirements-dev.txt; playwright install chromium }"
+	powershell -NoProfile -ExecutionPolicy Bypass -Command "& { . .venv\Scripts\Activate.ps1; python -m pip install --upgrade pip; pip install -r requirements-dev.txt; playwright install chromium }"
 else
-	$(PYTHON_BIN) -m venv .venv && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements.txt -r requirements-dev.txt && playwright install chromium
+	$(PYTHON_BIN) -m venv .venv && . .venv/bin/activate && python -m pip install --upgrade pip && pip install -r requirements-dev.txt && playwright install chromium
 endif
 
 .PHONY: audit

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ python -m venv .venv
 .venv\Scripts\Activate.ps1
 pip install --upgrade pip
 pip install -r requirements-dev.txt
-playwright install chromium
+python -m playwright install chromium
 ```
 
 The development checkout can run through source-tree wrappers, so editable

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ cp .env.example .env
 cp config/sites.yaml.example config/sites.yaml
 ```
 
+On Windows PowerShell:
+
+```powershell
+Copy-Item .env.example .env
+Copy-Item config\sites.yaml.example config\sites.yaml
+```
+
 3. Edit `config/sites.yaml` and `.env` for your site, credentials, and paths.
 
    The current authentication flow is validated for `headful` login only. The `email_code` and `password_only` auth types are not tested thoroughly and are not recommended for production use.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ If `make` is not available, create the environment directly:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install -r requirements-dev.txt
-playwright install chromium
-python -m pip install -e .
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -r requirements-dev.txt
+.venv/bin/python -m playwright install chromium
+.venv/bin/python -m pip install -e .
 ```
 
 On Windows PowerShell without `make`:
@@ -40,10 +40,10 @@ On Windows PowerShell without `make`:
 ```powershell
 python -m venv .venv
 .venv\Scripts\Activate.ps1
-python -m pip install --upgrade pip
-python -m pip install -r requirements-dev.txt
-playwright install chromium
-python -m pip install -e .
+.venv\Scripts\python.exe -m pip install --upgrade pip
+.venv\Scripts\python.exe -m pip install -r requirements-dev.txt
+.venv\Scripts\python.exe -m playwright install chromium
+.venv\Scripts\python.exe -m pip install -e .
 ```
 
 2. Create local configuration files:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements-dev.txt
-playwright install chromium
+python -m playwright install chromium
 ```
 
 On Windows PowerShell without `make`:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ## Quick Start
 
-1. Create and activate the environment, then install the project commands:
+1. Create and activate the environment, then install the project commands.
+
+If `make` is available:
 
 ```bash
 make local-venv
@@ -21,6 +23,28 @@ python -m pip install -e .
 ```
 
 `make local-venv` creates and populates `.venv`, but activation still has to be run in your current shell.
+
+If `make` is not available, create the environment directly:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-dev.txt
+playwright install chromium
+python -m pip install -e .
+```
+
+On Windows PowerShell without `make`:
+
+```powershell
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-dev.txt
+playwright install chromium
+python -m pip install -e .
+```
 
 2. Create local configuration files:
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@
 
 ## Quick Start
 
-1. Create and activate the environment, then install the project commands.
+1. Create and activate the development environment.
 
 If `make` is available:
 
 ```bash
 make local-venv
 source .venv/bin/activate
-python -m pip install -e .
 ```
 
 On Windows PowerShell:
@@ -19,7 +18,6 @@ On Windows PowerShell:
 ```powershell
 make local-venv
 .venv\Scripts\Activate.ps1
-python -m pip install -e .
 ```
 
 `make local-venv` creates and populates `.venv`, but activation still has to be run in your current shell.
@@ -32,7 +30,6 @@ source .venv/bin/activate
 .venv/bin/python -m pip install --upgrade pip
 .venv/bin/python -m pip install -r requirements-dev.txt
 .venv/bin/python -m playwright install chromium
-.venv/bin/python -m pip install -e .
 ```
 
 On Windows PowerShell without `make`:
@@ -40,10 +37,18 @@ On Windows PowerShell without `make`:
 ```powershell
 python -m venv .venv
 .venv\Scripts\Activate.ps1
-.venv\Scripts\python.exe -m pip install --upgrade pip
-.venv\Scripts\python.exe -m pip install -r requirements-dev.txt
-.venv\Scripts\python.exe -m playwright install chromium
-.venv\Scripts\python.exe -m pip install -e .
+pip install --upgrade pip
+pip install -r requirements-dev.txt
+playwright install chromium
+```
+
+The development checkout can run through source-tree wrappers, so editable
+install is not required. If you want the `docmcp-auth`, `docmcp-crawl`, and
+`docmcp-server` console commands in this environment, run this after activating
+`.venv`:
+
+```bash
+python -m pip install -e .
 ```
 
 2. Create local configuration files:
@@ -60,20 +65,20 @@ cp config/sites.yaml.example config/sites.yaml
 4. Authenticate the site:
 
 ```bash
-docmcp-auth --list
-docmcp-auth --site "My Docs"
+python auth_cli.py --list
+python auth_cli.py --site "My Docs"
 ```
 
 5. Crawl and index the site:
 
 ```bash
-docmcp-crawl --site "My Docs"
+python crawl_cli.py --site "My Docs"
 ```
 
 6. Start the MCP server:
 
 ```bash
-docmcp-server
+python -m src.main
 ```
 
 ## Install On Another Environment

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If `make` is not available, create the environment directly:
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt -r requirements-dev.txt
+python -m pip install -r requirements-dev.txt
 playwright install chromium
 python -m pip install -e .
 ```
@@ -41,7 +41,7 @@ On Windows PowerShell without `make`:
 python -m venv .venv
 .venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt -r requirements-dev.txt
+python -m pip install -r requirements-dev.txt
 playwright install chromium
 python -m pip install -e .
 ```

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ If `make` is not available, create the environment directly:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-.venv/bin/python -m pip install --upgrade pip
-.venv/bin/python -m pip install -r requirements-dev.txt
-.venv/bin/python -m playwright install chromium
+pip install --upgrade pip
+pip install -r requirements-dev.txt
+playwright install chromium
 ```
 
 On Windows PowerShell without `make`:

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -5,10 +5,11 @@
 - Owner: Documentation Maintainers
 - Reviewers: Repository maintainers
 - Created: 2026-04-24
-- Last Updated: 2026-04-25
-- Version: v1.1
+- Last Updated: 2026-04-27
+- Version: v1.2
 
 ## Change Log
+- 2026-04-27 | v1.2 | Clarified that Make is optional and documented direct Python virtual environment setup.
 - 2026-04-25 | v1.1 | Updated setup and verification commands for the package entry points and explicit virtual environment activation.
 - 2026-04-24 | v1.0 | Reformatted the setup guide to the documentation standard and kept the install paths and verification commands.
 
@@ -27,10 +28,10 @@ Provide the shortest path to a working local environment for `doc-mcp`, includin
 ## Design / Behavior
 ### Prerequisites
 - Python 3.11 or newer
-- GNU Make, recommended
+- GNU Make, optional but recommended for the fastest setup path
 - A Chromium browser installation through Playwright
 
-### Fastest Setup
+### Fastest Setup With Make
 ```bash
 make local-venv
 ```
@@ -55,14 +56,14 @@ If you want the `docmcp-auth`, `docmcp-crawl`, and `docmcp-server` console comma
 pip install -e .
 ```
 
-### Manual Setup
+### Manual Setup Without Make
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-dev.txt
 playwright install chromium
-pip install -e .
+python -m pip install -e .
 ```
 
 On Windows:
@@ -70,10 +71,10 @@ On Windows:
 ```powershell
 python -m venv .venv
 .venv\Scripts\Activate.ps1
-pip install -r requirements.txt
-pip install -r requirements-dev.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-dev.txt
 playwright install chromium
-pip install -e .
+python -m pip install -e .
 ```
 
 ### Verify The Environment

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -6,10 +6,10 @@
 - Reviewers: Repository maintainers
 - Created: 2026-04-24
 - Last Updated: 2026-04-27
-- Version: v1.2
+- Version: v1.3
 
 ## Change Log
-- 2026-04-27 | v1.2 | Clarified that Make is optional and documented direct Python virtual environment setup.
+- 2026-04-27 | v1.3 | Clarified that Make is optional and updated development setup to install runtime dependencies through requirements-dev.txt.
 - 2026-04-25 | v1.1 | Updated setup and verification commands for the package entry points and explicit virtual environment activation.
 - 2026-04-24 | v1.0 | Reformatted the setup guide to the documentation standard and kept the install paths and verification commands.
 
@@ -61,7 +61,7 @@ pip install -e .
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt -r requirements-dev.txt
+python -m pip install -r requirements-dev.txt
 playwright install chromium
 python -m pip install -e .
 ```
@@ -72,7 +72,7 @@ On Windows:
 python -m venv .venv
 .venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt -r requirements-dev.txt
+python -m pip install -r requirements-dev.txt
 playwright install chromium
 python -m pip install -e .
 ```

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -6,10 +6,10 @@
 - Reviewers: Repository maintainers
 - Created: 2026-04-24
 - Last Updated: 2026-04-27
-- Version: v1.3
+- Version: v1.5
 
 ## Change Log
-- 2026-04-27 | v1.3 | Clarified that Make is optional and updated development setup to install runtime dependencies through requirements-dev.txt.
+- 2026-04-27 | v1.5 | Clarified optional Make setup and updated dependency and Playwright installation to run through the explicit virtual environment Python.
 - 2026-04-25 | v1.1 | Updated setup and verification commands for the package entry points and explicit virtual environment activation.
 - 2026-04-24 | v1.0 | Reformatted the setup guide to the documentation standard and kept the install paths and verification commands.
 
@@ -60,10 +60,10 @@ pip install -e .
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install -r requirements-dev.txt
-playwright install chromium
-python -m pip install -e .
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -r requirements-dev.txt
+.venv/bin/python -m playwright install chromium
+.venv/bin/python -m pip install -e .
 ```
 
 On Windows:
@@ -71,10 +71,10 @@ On Windows:
 ```powershell
 python -m venv .venv
 .venv\Scripts\Activate.ps1
-python -m pip install --upgrade pip
-python -m pip install -r requirements-dev.txt
-playwright install chromium
-python -m pip install -e .
+.venv\Scripts\python.exe -m pip install --upgrade pip
+.venv\Scripts\python.exe -m pip install -r requirements-dev.txt
+.venv\Scripts\python.exe -m playwright install chromium
+.venv\Scripts\python.exe -m pip install -e .
 ```
 
 ### Verify The Environment
@@ -92,6 +92,14 @@ Installed package commands:
 docmcp-auth --help
 docmcp-crawl --help
 docmcp-server
+```
+
+On Windows, do not rely on a standalone `playwright` file being visible in
+`.venv\Scripts`. Verify Playwright through the virtual environment Python:
+
+```powershell
+.venv\Scripts\python.exe -m pip show playwright
+.venv\Scripts\python.exe -m playwright --version
 ```
 
 ### Build And Install A Wheel On Another Environment
@@ -124,6 +132,7 @@ docmcp-server
 - If `make` is not available, use the manual setup commands.
 - If the virtual environment is not active, the CLI commands will use whatever Python is on `PATH`.
 - If Chromium is missing, Playwright-based auth and crawl commands will fail before the first site run.
+- If `.venv\Scripts\python.exe -m playwright --version` fails with `No module named playwright`, reinstall dependencies with `.venv\Scripts\python.exe -m pip install -r requirements-dev.txt`.
 
 ## References
 - [README.md](../README.md)

--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -6,10 +6,10 @@
 - Reviewers: Repository maintainers
 - Created: 2026-04-24
 - Last Updated: 2026-04-27
-- Version: v1.5
+- Version: v1.6
 
 ## Change Log
-- 2026-04-27 | v1.5 | Clarified optional Make setup and updated dependency and Playwright installation to run through the explicit virtual environment Python.
+- 2026-04-27 | v1.6 | Clarified optional Make setup, Playwright installation, and optional editable install for source-tree development.
 - 2026-04-25 | v1.1 | Updated setup and verification commands for the package entry points and explicit virtual environment activation.
 - 2026-04-24 | v1.0 | Reformatted the setup guide to the documentation standard and kept the install paths and verification commands.
 
@@ -50,7 +50,7 @@ On Windows PowerShell:
 .venv\Scripts\Activate.ps1
 ```
 
-If you want the `docmcp-auth`, `docmcp-crawl`, and `docmcp-server` console commands, install the project itself in editable mode:
+The source-tree wrappers work without installing the package itself. If you want the `docmcp-auth`, `docmcp-crawl`, and `docmcp-server` console commands, install the project in editable mode:
 
 ```bash
 pip install -e .
@@ -63,7 +63,6 @@ source .venv/bin/activate
 .venv/bin/python -m pip install --upgrade pip
 .venv/bin/python -m pip install -r requirements-dev.txt
 .venv/bin/python -m playwright install chromium
-.venv/bin/python -m pip install -e .
 ```
 
 On Windows:
@@ -74,7 +73,12 @@ python -m venv .venv
 .venv\Scripts\python.exe -m pip install --upgrade pip
 .venv\Scripts\python.exe -m pip install -r requirements-dev.txt
 .venv\Scripts\python.exe -m playwright install chromium
-.venv\Scripts\python.exe -m pip install -e .
+```
+
+Editable install remains optional for source-tree development. Use it only when you need the package console commands:
+
+```bash
+python -m pip install -e .
 ```
 
 ### Verify The Environment

--- a/documentation/manual-test-scenarios.md
+++ b/documentation/manual-test-scenarios.md
@@ -78,7 +78,9 @@ Run this block first when validating the repository checkout directly.
        - `.venv\Scripts\python.exe -m pip install --upgrade pip`
        - `.venv\Scripts\python.exe -m pip install -r requirements-dev.txt`
        - `.venv\Scripts\python.exe -m playwright install chromium`
-  3. If `make local-venv` was used, activate the virtual environment with `source .venv/bin/activate`.
+  3. If `make local-venv` was used, activate the virtual environment:
+     - macOS/Linux: `source .venv/bin/activate`
+     - Windows PowerShell: `.venv\Scripts\Activate.ps1`
   4. Run `python auth_cli.py --help`.
   5. Run `python crawl_cli.py --help`.
   6. Run `python -c "import src.docmcp.main"` to verify the server module imports.

--- a/documentation/manual-test-scenarios.md
+++ b/documentation/manual-test-scenarios.md
@@ -5,10 +5,11 @@
 - Owner: Documentation Maintainers
 - Reviewers: Repository maintainers
 - Created: 2026-04-26
-- Last Updated: 2026-04-26
-- Version: v0.3
+- Last Updated: 2026-04-27
+- Version: v0.4
 
 ## Change Log
+- 2026-04-27 | v0.4 | Clarified development environment setup with and without Make.
 - 2026-04-26 | v0.3 | Added manual verification scenarios with separate development and installed-wheel runtime flows.
 
 ## Purpose
@@ -63,11 +64,24 @@ Run this block first when validating the repository checkout directly.
 
 ### MT-001A: Create Development Source-Tree Environment
 - Steps:
-  1. Run `make local-venv`.
-  2. Activate the virtual environment with `source .venv/bin/activate`.
-  3. Run `python auth_cli.py --help`.
-  4. Run `python crawl_cli.py --help`.
-  5. Run `python -c "import src.docmcp.main"` to verify the server module imports.
+  1. If `make` is available, run `make local-venv`.
+  2. If `make` is not available, create the environment directly:
+     - macOS/Linux:
+       - `python3 -m venv .venv`
+       - `source .venv/bin/activate`
+       - `python -m pip install --upgrade pip`
+       - `python -m pip install -r requirements.txt -r requirements-dev.txt`
+       - `playwright install chromium`
+     - Windows PowerShell:
+       - `python -m venv .venv`
+       - `.venv\Scripts\Activate.ps1`
+       - `python -m pip install --upgrade pip`
+       - `python -m pip install -r requirements.txt -r requirements-dev.txt`
+       - `playwright install chromium`
+  3. If `make local-venv` was used, activate the virtual environment with `source .venv/bin/activate`.
+  4. Run `python auth_cli.py --help`.
+  5. Run `python crawl_cli.py --help`.
+  6. Run `python -c "import src.docmcp.main"` to verify the server module imports.
 - Expected result:
   - The virtual environment is created.
   - Chromium is installed by Playwright.

--- a/documentation/manual-test-scenarios.md
+++ b/documentation/manual-test-scenarios.md
@@ -6,10 +6,10 @@
 - Reviewers: Repository maintainers
 - Created: 2026-04-26
 - Last Updated: 2026-04-27
-- Version: v0.5
+- Version: v0.7
 
 ## Change Log
-- 2026-04-27 | v0.5 | Clarified development environment setup with and without Make and updated dependency installation through requirements-dev.txt.
+- 2026-04-27 | v0.7 | Clarified development setup with and without Make and updated dependency and Playwright installation to run through the explicit virtual environment Python.
 - 2026-04-26 | v0.3 | Added manual verification scenarios with separate development and installed-wheel runtime flows.
 
 ## Purpose
@@ -69,15 +69,15 @@ Run this block first when validating the repository checkout directly.
      - macOS/Linux:
        - `python3 -m venv .venv`
        - `source .venv/bin/activate`
-       - `python -m pip install --upgrade pip`
-       - `python -m pip install -r requirements-dev.txt`
-       - `playwright install chromium`
+       - `.venv/bin/python -m pip install --upgrade pip`
+       - `.venv/bin/python -m pip install -r requirements-dev.txt`
+       - `.venv/bin/python -m playwright install chromium`
      - Windows PowerShell:
        - `python -m venv .venv`
        - `.venv\Scripts\Activate.ps1`
-       - `python -m pip install --upgrade pip`
-       - `python -m pip install -r requirements-dev.txt`
-       - `playwright install chromium`
+       - `.venv\Scripts\python.exe -m pip install --upgrade pip`
+       - `.venv\Scripts\python.exe -m pip install -r requirements-dev.txt`
+       - `.venv\Scripts\python.exe -m playwright install chromium`
   3. If `make local-venv` was used, activate the virtual environment with `source .venv/bin/activate`.
   4. Run `python auth_cli.py --help`.
   5. Run `python crawl_cli.py --help`.
@@ -137,8 +137,12 @@ Run this block after the development environment passes, using a separate runtim
      - Windows PowerShell:
        - `python -m venv .venv`
        - `.venv\Scripts\Activate.ps1`
-  4. Install the built wheel with `python -m pip install /path/to/doc_mcp-*.whl`.
-  5. Install Chromium with `playwright install chromium`.
+  4. Install the built wheel:
+     - macOS/Linux: `.venv/bin/python -m pip install /path/to/doc_mcp-*.whl`
+     - Windows PowerShell: `.venv\Scripts\python.exe -m pip install /path/to/doc_mcp-*.whl`
+  5. Install Chromium:
+     - macOS/Linux: `.venv/bin/python -m playwright install chromium`
+     - Windows PowerShell: `.venv\Scripts\python.exe -m playwright install chromium`
   6. Run `docmcp-auth --help`.
   7. Run `docmcp-crawl --help`.
   8. Run `command -v docmcp-server` to verify the server console script is installed.

--- a/documentation/manual-test-scenarios.md
+++ b/documentation/manual-test-scenarios.md
@@ -6,10 +6,10 @@
 - Reviewers: Repository maintainers
 - Created: 2026-04-26
 - Last Updated: 2026-04-27
-- Version: v0.4
+- Version: v0.5
 
 ## Change Log
-- 2026-04-27 | v0.4 | Clarified development environment setup with and without Make.
+- 2026-04-27 | v0.5 | Clarified development environment setup with and without Make and updated dependency installation through requirements-dev.txt.
 - 2026-04-26 | v0.3 | Added manual verification scenarios with separate development and installed-wheel runtime flows.
 
 ## Purpose
@@ -70,13 +70,13 @@ Run this block first when validating the repository checkout directly.
        - `python3 -m venv .venv`
        - `source .venv/bin/activate`
        - `python -m pip install --upgrade pip`
-       - `python -m pip install -r requirements.txt -r requirements-dev.txt`
+       - `python -m pip install -r requirements-dev.txt`
        - `playwright install chromium`
      - Windows PowerShell:
        - `python -m venv .venv`
        - `.venv\Scripts\Activate.ps1`
        - `python -m pip install --upgrade pip`
-       - `python -m pip install -r requirements.txt -r requirements-dev.txt`
+       - `python -m pip install -r requirements-dev.txt`
        - `playwright install chromium`
   3. If `make local-venv` was used, activate the virtual environment with `source .venv/bin/activate`.
   4. Run `python auth_cli.py --help`.

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -48,7 +48,7 @@ List the most common failure modes for `doc-mcp` and the first corrective step f
 
 ### Missing Markdown Conversion
 - If `markdownify` is not installed, the crawler falls back to plain text extraction.
-- Install dependencies through `make local-venv` or `pip install -r requirements.txt`.
+- Install development dependencies through `make local-venv` or `python -m pip install -r requirements-dev.txt`.
 
 ### Windows Console Output Looks Broken
 - `src/docmcp/main.py` reconfigures stdout and stderr to UTF-8.

--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -5,10 +5,11 @@
 - Owner: Documentation Maintainers
 - Reviewers: Repository maintainers
 - Created: 2026-04-24
-- Last Updated: 2026-04-25
-- Version: v1.1
+- Last Updated: 2026-04-27
+- Version: v1.2
 
 ## Change Log
+- 2026-04-27 | v1.2 | Added Windows Playwright module verification and recovery steps.
 - 2026-04-25 | v1.1 | Updated troubleshooting notes for the package entry point and VS Code MCP configuration.
 - 2026-04-24 | v1.0 | Reformatted the troubleshooting guide and grouped the common failures into standard sections.
 
@@ -49,6 +50,13 @@ List the most common failure modes for `doc-mcp` and the first corrective step f
 ### Missing Markdown Conversion
 - If `markdownify` is not installed, the crawler falls back to plain text extraction.
 - Install development dependencies through `make local-venv` or `python -m pip install -r requirements-dev.txt`.
+
+### Windows Playwright Module Is Missing
+- A standalone `playwright` script may not be visible in `.venv\Scripts`; use the virtual environment Python instead.
+- Verify the package with `.venv\Scripts\python.exe -m pip show playwright`.
+- Verify the CLI module with `.venv\Scripts\python.exe -m playwright --version`.
+- If verification fails with `No module named playwright`, reinstall dependencies with `.venv\Scripts\python.exe -m pip install -r requirements-dev.txt`.
+- Install Chromium with `.venv\Scripts\python.exe -m playwright install chromium`.
 
 ### Windows Console Output Looks Broken
 - `src/docmcp/main.py` reconfigures stdout and stderr to UTF-8.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
 classifiers = [
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.11",
   "Topic :: Documentation",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+-r requirements.txt
+
 # Dependency auditing
 build>=1.2,<2
 pip-audit>=2.7,<3


### PR DESCRIPTION
## Summary
- Clarifies source-tree development setup in README and docs, including no-`make` and Windows PowerShell paths.
- Makes `requirements-dev.txt` include runtime requirements so dev setup installs from one requirements file.
- Updates Playwright setup guidance to use the active virtual environment and adds Windows troubleshooting notes.
- Fixes wheel builds by removing the deprecated MIT license classifier, disabling build isolation for the local `make wheel` target, and cleaning stale build output before packaging.

## Verification
- `make wheel`
- `pre-commit run --all-files`
